### PR TITLE
fix startVar for ruin and semi working ruin

### DIFF
--- a/src/maps/ruin.ts
+++ b/src/maps/ruin.ts
@@ -134,7 +134,7 @@ export class HMapRuin extends HMapAbstractMap<HMapRuinDataJSON, HMapRuinLocalDat
 
                 ruinLayer.easeMovement({ x: 300 * x, y: 300 * y }, () => {
                     if (data.indexOf('js.JsExplo.init') !== -1) {
-                        const startVar = data.indexOf('js.JsExplo.init') + 16;
+                        const startVar = data.indexOf('js.JsExplo.init') + 18;
                         const stopVar = data.indexOf('\',', startVar);
                         const tempMapData = data.substring(startVar, stopVar);
 
@@ -215,7 +215,7 @@ export class HMapRuin extends HMapAbstractMap<HMapRuinDataJSON, HMapRuinLocalDat
                 this.hmap.originalOnData!(data); // we are sure the function has been set
 
                 if (data.indexOf('js.JsExplo.init') !== -1) {
-                    const startVar = data.indexOf('js.JsExplo.init') + 16;
+                    const startVar = data.indexOf('js.JsExplo.init') + 18;
                     const stopVar = data.indexOf('\',', startVar);
                     const tempMapData = data.substring(startVar, stopVar);
 
@@ -262,7 +262,7 @@ export class HMapRuin extends HMapAbstractMap<HMapRuinDataJSON, HMapRuinLocalDat
                 this.hmap.originalOnData!(data); // we are sure the function has been set
 
                 if (data.indexOf('js.JsExplo.init') !== -1) {
-                    const startVar = data.indexOf('js.JsExplo.init') + 16;
+                    const startVar = data.indexOf('js.JsExplo.init') + 18;
                     const stopVar = data.indexOf('\',', startVar);
                     const tempMapData = data.substring(startVar, stopVar);
 


### PR DESCRIPTION
For js.JsExplo.init it's 18, 16 is for js.JsMap.init
working ruin after that
![image](https://user-images.githubusercontent.com/4539516/105925324-3519f880-6040-11eb-919e-acbbbd932388.png)

But we then have the next bug :D.

I moved to the left after the image and it give me that:
![image](https://user-images.githubusercontent.com/4539516/105925417-68f51e00-6040-11eb-84ce-1575f852703d.png)
Ruin explorer is correct and hmap a inverted left and right
